### PR TITLE
修复正则表达式匹配太宽泛的问题

### DIFF
--- a/alidns.sh
+++ b/alidns.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-FLAG=".com.cn|.gov.cn|.net.cn|.org.cn|.ac.cn|.gd.cn"  
+FLAG="(\.com\.cn|\.gov\.cn|\.net\.cn|\.org\.cn|\.ac\.cn|\.gd\.cn)$"
 
 
 if ! command -v aliyun >/dev/null; then


### PR DESCRIPTION
FLAG 里的正则表达式会匹配 com.cnxxx.org www.comxcn.org 这样的域名。修复一下。