### PR TITLE
用 grep -E 代替 egrep

### DIFF
--- a/alidns.sh
+++ b/alidns.sh
@@ -10,7 +10,7 @@ fi
 DOMAIN=$(expr match "$CERTBOT_DOMAIN" '.*\.\(.*\..*\)')
 SUB_DOMAIN=$(expr match "$CERTBOT_DOMAIN" '\(.*\)\..*\..*')
 
-if echo $CERTBOT_DOMAIN |egrep -q "$FLAG"; then
+if echo $CERTBOT_DOMAIN |grep -E -q "$FLAG"; then
 
   DOMAIN=`echo $CERTBOT_DOMAIN |grep -oP '(?<=)[^.]+('$FLAG')'`
   SUB_DOMAIN=`echo $CERTBOT_DOMAIN |grep -oP '.*(?=\.[^.]+('$FLAG'))'`


### PR DESCRIPTION
egrep 已经被弃用了，我的 certbot 执行的时候会报错：
```
Hook '--manual-auth-hook' for [redacted] ran with error output:                                                                                                                     
 egrep: warning: egrep is obsolescent; using grep -E 
```