### PR TITLE
fix: move cron job setup to entrypoint for dynamic configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,6 @@ ENV DOMAIN=""
 ENV EMAIL=""
 ENV CRON_SCHEDULE="0 0 * * *"
 
-# Setup cron job for certbot renew
-RUN echo "$CRON_SCHEDULE /opt/venv/bin/certbot renew --manual --preferred-challenges dns --manual-auth-hook '/usr/local/bin/alidns' --manual-cleanup-hook '/usr/local/bin/alidns clean' --agree-tos --email $EMAIL --deploy-hook 'cp -r /etc/letsencrypt/live/$DOMAIN/* /etc/letsencrypt/certs'" > /etc/crontabs/root
-
 # Create directory for certificates
 RUN mkdir -p /etc/letsencrypt/certs
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ aliyun configure set --profile akProfile --mode AK --region $REGION --access-key
 certbot certonly -d "$DOMAIN" --manual --preferred-challenges dns --manual-auth-hook "/usr/local/bin/alidns" --manual-cleanup-hook "/usr/local/bin/alidns clean" --agree-tos --email $EMAIL --non-interactive
 
 # Setup cron job for certbot renew dynamically
-echo "$CRON_SCHEDULE /opt/venv/bin/certbot renew --manual --preferred-challenges dns --manual-auth-hook '/usr/local/bin/alidns' --manual-cleanup-hook '/usr/local/bin/alidns clean' --agree-tos --email $EMAIL --deploy-hook 'cp -r /etc/letsencrypt/live/$DOMAIN/* /etc/letsencrypt/certs'" > /etc/crontabs/root
+echo "$CRON_SCHEDULE /opt/venv/bin/certbot renew --manual --preferred-challenges dns --manual-auth-hook '/usr/local/bin/alidns' --manual-cleanup-hook '/usr/local/bin/alidns clean' --agree-tos --email $EMAIL --deploy-hook \"cp -r /etc/letsencrypt/live/\\\$DOMAIN/* /etc/letsencrypt/certs\"" > /etc/crontabs/root
 
 # Start cron daemon
 crond -f -l 2

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,8 @@ aliyun configure set --profile akProfile --mode AK --region $REGION --access-key
 # Obtain the certificate
 certbot certonly -d "$DOMAIN" --manual --preferred-challenges dns --manual-auth-hook "/usr/local/bin/alidns" --manual-cleanup-hook "/usr/local/bin/alidns clean" --agree-tos --email $EMAIL --non-interactive
 
+# Setup cron job for certbot renew dynamically
+echo "$CRON_SCHEDULE /opt/venv/bin/certbot renew --manual --preferred-challenges dns --manual-auth-hook '/usr/local/bin/alidns' --manual-cleanup-hook '/usr/local/bin/alidns clean' --agree-tos --email $EMAIL --deploy-hook 'cp -r /etc/letsencrypt/live/$DOMAIN/* /etc/letsencrypt/certs'" > /etc/crontabs/root
+
 # Start cron daemon
 crond -f -l 2
-


### PR DESCRIPTION
将dockerfile中设置cron的逻辑迁移到了entrypoint中